### PR TITLE
🔧(renovate) set prCreation to immediate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
     ],
     "prConcurrentLimit": 2,
     "prHourlyLimit": 2,
-    "prCreation": "not-pending",
+    "prCreation": "immediate",
     "semanticCommits": "disabled",
     "separateMajorMinor": false,
     "updateNotScheduled": true,


### PR DESCRIPTION
## Purpos
Previously, prCreation was set to `not-pending` which prevent PR creation until branch checks succeeded or failed. But for some of our repository (e.g: [Richie](https://github.com/openfun/richie)) check jobs did not run on branch without an associated PR, so renovate never created PR.

The only drawback is we will not see immediately if renovate PR checks failed or succeedded.

## Proposal

- [x] Update `prCreation` from `not-pending` to `immediate`