### PR TITLE
🔧(default) disabled dependency dashboard

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,6 +2,7 @@
     "commitMessageAction": "update",
     "commitMessagePrefix": "⬆️(dependencies)",
     "commitMessageTopic": "{{depName}}",
+    "dependencyDashboard": false,
     "enabledManagers": ["npm", "setup-cfg"],
     "extends": ["config:base"],
     "labels": ["dependencies"],


### PR DESCRIPTION
Since v26.0.0, dependencyDashboard is enable by default. This results in the creation of an issue which resumes the renovate state. We do not want this behaviour so we set `dependencyDashboard` to `false`