### PR TITLE
🧑‍💻(renovate) support usage of `pyproject.toml` in Python

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,7 @@
     "commitMessagePrefix": "⬆️(dependencies)",
     "commitMessageTopic": "{{depName}}",
     "dependencyDashboard": false,
-    "enabledManagers": ["npm", "setup-cfg"],
+    "enabledManagers": ["npm", "setup-cfg", "pep621"],
     "extends": ["config:base"],
     "labels": ["dependencies"],
     "packageRules": [
@@ -15,7 +15,7 @@
       },
       {
         "groupName": "python dependencies",
-        "matchManagers": ["setup-cfg"],
+        "matchManagers": ["setup-cfg", "pep621"],
         "schedule": ["before 7am on monday"],
         "matchPackagePatterns": ["*"]
       }


### PR DESCRIPTION
Enhance the default configurations by adding support for `pyproject.toml`. It offers a standardized and user-friendly method to configure Python projects, which should be supported by default. The inclusion of a new package manager was necessary.